### PR TITLE
Network Monitor Bug Fix

### DIFF
--- a/doc/DESIGN_AND_FEATURES.md
+++ b/doc/DESIGN_AND_FEATURES.md
@@ -71,7 +71,7 @@ If the alerter is not in sync with the validator with respect to block height, t
 
 In each monitoring round, the network monitor:
 
-1. Gets the node's abci info from `[RPC_URL]/abci_info`
+1. Gets the node's abci info from `[RPC_URL]/status`
     1. Gets the latest block height *LastH*
 2. Sets *H* = *LastHChecked* + 1 where *LastHChecked is the height of the last block checked by the network monitor
 3. If *LastH* - *LastHChecked* > `MCUB`:

--- a/src/monitoring/monitors/network.py
+++ b/src/monitoring/monitors/network.py
@@ -125,10 +125,14 @@ class NetworkMonitor(Monitor):
         self._logger.debug('Moving to next height.')
 
     def monitor(self) -> None:
-        # Get abci_info and, from that, the last height to be checked
-        abci_info = get_cosmos_json(self.node.rpc_url + '/abci_info',
-                                    self._logger)
-        last_height_to_check = int(abci_info['response']['last_block_height'])
+        # Get node status and, from that, the last height to be checked
+        status = get_cosmos_json(self.node.rpc_url + '/status',
+                                 self._logger)
+        last_height_to_check = int(status['sync_info']['latest_block_height'])
+
+        # If the chain has not started, return as there are no blocks to get
+        if last_height_to_check == 0:
+            return
 
         # If this is the first height being checked, ignore previous heights
         if self._last_height_checked is None:


### PR DESCRIPTION
Closes #35 

Network monitor now uses `/status` endpoint to get the latest block height, which might be zero during chain startup, whereas it is missing from `/abci_info` during chain startup. A check for zero height was added, in which case the monitor does not do anything until height is non-zero.